### PR TITLE
Updated helper function to match the signature of laravel helpers

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,12 +5,16 @@ use Efriandika\LaravelSettings\Facades\Settings;
 if (!function_exists('settings'))
 {
     /**
-     * @param $key
+     * @param string|null $key
      * @param null $default
      * @return mixed|\Efriandika\LaravelSettings\Facades\Settings
      */
-    function settings($key, $default = null)
+    function settings($key = null, $default = null)
     {
+        if (is_null($key)) {
+            return app('settings');
+        }
+
         return Settings::get($key, $default);
     }
 }


### PR DESCRIPTION
I made it so that you can use the `settings()->set()` and `settings()->get()` syntax which Laravel allows when using most of the inbuilt helpers (such as `route()`, `view()` and `config()`).
